### PR TITLE
Tell ember-auto-import to ignore glimmer import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 'use strict';
 
 module.exports = {
-  name: require('./package').name
+  name: require('./package').name,
+  options: {
+    autoImport: {
+      exclude: ['@glimmer/component']
+    }
+  }
 };


### PR DESCRIPTION
Since we are importing `@glimmer/component` for its type info only, we can tell `ember-auto-import` to ignore it as a required runtime dependency.

This config may be unnecessary if https://github.com/ef4/ember-auto-import/issues/169 is addressed.