### PR TITLE
Add failing test for context in property initializer

### DIFF
--- a/tests/dummy/app/components/character.hbs
+++ b/tests/dummy/app/components/character.hbs
@@ -1,5 +1,6 @@
 <div class="character" role="button" {{on "click" this.onClick}}>
   <div class="id">{{this.id}}</div>
+  <div class="_id">{{this._id}}</div>
   <div class="name">{{this.name}}</div>
   <div class="title">{{this.title}}</div>
   <div class="tunic">{{this.tunic}}</div>

--- a/tests/dummy/app/components/character.js
+++ b/tests/dummy/app/components/character.js
@@ -11,6 +11,10 @@ export default class CharacterComponent extends Component {
     return guidFor(this);
   }
 
+  get _id() {
+    return guidFor(this);
+  }
+
   @arg(string.isRequired)
   name;
 

--- a/tests/integration/components/args-decorator-test.ts
+++ b/tests/integration/components/args-decorator-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, skip, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 //@ts-ignore
@@ -19,6 +19,15 @@ module('Integration | Component | arg-decorator', function(hooks) {
     assert.dom('.title').hasText('hero of time', '@arg can use an initialized value as a default');
     assert.dom('.hearts').hasText('12', '@arg() can use an initialized value as a default');
     assert.dom('.level').hasNoText('@arg will pass `undefined` as a default when an initializer is not present');
+  });
+
+  skip('it uses the correct context in property initializers', async function(assert) {
+    await render(hbs`<Character @name="link" />`);
+
+    const argId = this.element.querySelector('.id')!.textContent;
+    const privateId = this.element.querySelector('._id')!.textContent;
+
+    assert.equal(argId, privateId, '@arg calls the default getter with the correct context');
   });
 
   test('it allows default overrides', async function(assert) {


### PR DESCRIPTION
It seems that having:

```javascript
@arg(string)
get id() {
  return guidFor(this);
}
```

generates the same `id` value for each component instance.

This PR adds a failing test for this.

Let me know if I need to change/reword anything.