### PR TITLE
Update `ember-get-config` to v2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ember-arg-types",
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
@@ -13,7 +14,7 @@
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^5.7.1",
         "ember-cli-typescript": "^4.0.0",
-        "ember-get-config": "^0.2.4 || ^0.3.0",
+        "ember-get-config": "^2.1.1",
         "prop-types": "^15.7.2"
       },
       "devDependencies": {
@@ -1906,6 +1907,82 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@embroider/shared-internals": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.8.1.tgz",
+      "integrity": "sha512-sP+QyVQ6pRYJ0QPQg+13kIVyKKWlFUN5jAkXiFqrx53oqMe+XPbqVxt9z+EcElOHNOec7Gmy03ISmY3fOaBkdQ==",
+      "dependencies": {
+        "babel-import-util": "^1.1.0",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/shared-internals/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@embroider/shared-internals/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@embroider/shared-internals/node_modules/resolve-package-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+      "dependencies": {
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@embroider/shared-internals/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@embroider/shared-internals/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@embroider/test-setup": {
@@ -4109,6 +4186,14 @@
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
+      }
+    },
+    "node_modules/babel-import-util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.2.2.tgz",
+      "integrity": "sha512-8HgkHWt5WawRFukO30TuaL9EiDUOdvyKtDwLma4uBNeUSDbOO0/hiPfavrOWxSS6J6TKXfukWHZ3wiqZhJ8ONQ==",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/babel-loader": {
@@ -9973,24 +10058,112 @@
       }
     },
     "node_modules/ember-get-config": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.3.0.tgz",
-      "integrity": "sha512-0e2pKzwW5lBZ4oJnvu9qHOht4sP1MWz/m3hyz8kpSoMdrlZVf62LDKZ6qfKgy8drcv5YhCMYE6QV7MhnqlrzEQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-2.1.1.tgz",
+      "integrity": "sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==",
       "dependencies": {
-        "broccoli-file-creator": "^1.1.1",
-        "ember-cli-babel": "^7.0.0"
+        "@embroider/macros": "^0.50.0 || ^1.0.0",
+        "ember-cli-babel": "^7.26.6"
       },
       "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
+        "node": "12.* || 14.* || >= 16"
       }
     },
-    "node_modules/ember-get-config/node_modules/broccoli-file-creator": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz",
-      "integrity": "sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==",
+    "node_modules/ember-get-config/node_modules/@embroider/macros": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.8.1.tgz",
+      "integrity": "sha512-P5yxwex95rRghKniycaPTtOiass/q+OTyHaSnlMJbIBN3cPYhEiNLoVDiSpC51EjMGx8FzQnndC51HG7We5ryQ==",
       "dependencies": {
-        "broccoli-plugin": "^1.1.0",
-        "mkdirp": "^0.5.1"
+        "@embroider/shared-internals": "1.8.1",
+        "assert-never": "^1.2.1",
+        "babel-import-util": "^1.1.0",
+        "ember-cli-babel": "^7.26.6",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-get-config/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-get-config/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-get-config/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-get-config/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-get-config/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-get-config/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ember-load-initializers": {
@@ -21422,9 +21595,9 @@
       }
     },
     "node_modules/typescript-memoize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.0.0.tgz",
-      "integrity": "sha512-B1eufjs/mGzHqoGeI1VT/dnSBoZr2v3i3/Wm8NmdxlZflyVdleE8wO0QwUuj4NfundD7T5nU3I7HSKp/5BD9og=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.1.0.tgz",
+      "integrity": "sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg=="
     },
     "node_modules/uc.micro": {
       "version": "1.0.6",
@@ -22591,7 +22764,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -24152,6 +24324,64 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        }
+      }
+    },
+    "@embroider/shared-internals": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.8.1.tgz",
+      "integrity": "sha512-sP+QyVQ6pRYJ0QPQg+13kIVyKKWlFUN5jAkXiFqrx53oqMe+XPbqVxt9z+EcElOHNOec7Gmy03ISmY3fOaBkdQ==",
+      "requires": {
+        "babel-import-util": "^1.1.0",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "resolve-package-path": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+          "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+          "requires": {
+            "path-root": "^0.1.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
         }
       }
     },
@@ -26102,6 +26332,11 @@
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
       }
+    },
+    "babel-import-util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.2.2.tgz",
+      "integrity": "sha512-8HgkHWt5WawRFukO30TuaL9EiDUOdvyKtDwLma4uBNeUSDbOO0/hiPfavrOWxSS6J6TKXfukWHZ3wiqZhJ8ONQ=="
     },
     "babel-loader": {
       "version": "8.2.2",
@@ -31122,21 +31357,73 @@
       "dev": true
     },
     "ember-get-config": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.3.0.tgz",
-      "integrity": "sha512-0e2pKzwW5lBZ4oJnvu9qHOht4sP1MWz/m3hyz8kpSoMdrlZVf62LDKZ6qfKgy8drcv5YhCMYE6QV7MhnqlrzEQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-2.1.1.tgz",
+      "integrity": "sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==",
       "requires": {
-        "broccoli-file-creator": "^1.1.1",
-        "ember-cli-babel": "^7.0.0"
+        "@embroider/macros": "^0.50.0 || ^1.0.0",
+        "ember-cli-babel": "^7.26.6"
       },
       "dependencies": {
-        "broccoli-file-creator": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz",
-          "integrity": "sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==",
+        "@embroider/macros": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.8.1.tgz",
+          "integrity": "sha512-P5yxwex95rRghKniycaPTtOiass/q+OTyHaSnlMJbIBN3cPYhEiNLoVDiSpC51EjMGx8FzQnndC51HG7We5ryQ==",
           "requires": {
-            "broccoli-plugin": "^1.1.0",
-            "mkdirp": "^0.5.1"
+            "@embroider/shared-internals": "1.8.1",
+            "assert-never": "^1.2.1",
+            "babel-import-util": "^1.1.0",
+            "ember-cli-babel": "^7.26.6",
+            "find-up": "^5.0.0",
+            "lodash": "^4.17.21",
+            "resolve": "^1.20.0",
+            "semver": "^7.3.2"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -40466,9 +40753,9 @@
       "dev": true
     },
     "typescript-memoize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.0.0.tgz",
-      "integrity": "sha512-B1eufjs/mGzHqoGeI1VT/dnSBoZr2v3i3/Wm8NmdxlZflyVdleE8wO0QwUuj4NfundD7T5nU3I7HSKp/5BD9og=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.1.0.tgz",
+      "integrity": "sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -41447,8 +41734,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-typescript": "^4.0.0",
-    "ember-get-config": "^0.2.4 || ^0.3.0",
+    "ember-get-config": "^2.1.1",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
`>= v2.1.0` should now work the same under Embroider as it does in a classic build.